### PR TITLE
Closes #61 Add explicit failure for deprecated input formats

### DIFF
--- a/__ideas4/FibonacciSequenceTests.cs
+++ b/__ideas4/FibonacciSequenceTests.cs
@@ -1,0 +1,15 @@
+using Algorithms.Sequences;
+
+namespace Algorithms.Tests.Sequences;
+
+public class FibonacciSequenceTests
+{
+    [Test]
+    public void First10ElementsCorrect()
+    {
+        var sequence = new FibonacciSequence().Sequence.Take(10);
+        BigInteger[] expected = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34];
+        sequence.SequenceEqual(expected)
+            .Should().BeTrue();
+    }
+}

--- a/__ideas4/InsertionSort.test.js
+++ b/__ideas4/InsertionSort.test.js
@@ -1,0 +1,25 @@
+import { insertionSortAlternativeImplementation } from '../InsertionSort'
+
+describe('insertionSortAlternativeImplementation', () => {
+  it('expects to work with empty array', () => {
+    expect(insertionSortAlternativeImplementation([])).toEqual([])
+  })
+
+  it('expects to return input array when array.length is less than 2', () => {
+    const input = [3]
+    expect(insertionSortAlternativeImplementation(input)).toEqual(input)
+  })
+
+  it('expects to return array sorted in ascending order', () => {
+    expect(insertionSortAlternativeImplementation([14, 11])).toEqual([11, 14])
+    expect(insertionSortAlternativeImplementation([21, 22, 23])).toEqual([
+      21, 22, 23
+    ])
+    expect(insertionSortAlternativeImplementation([1, 3, 2, 3, 7, 2])).toEqual([
+      1, 2, 2, 3, 3, 7
+    ])
+    expect(insertionSortAlternativeImplementation([1, 6, 4, 5, 9, 2])).toEqual([
+      1, 2, 4, 5, 6, 9
+    ])
+  })
+})

--- a/__ideas4/data_normalization_standardization.r
+++ b/__ideas4/data_normalization_standardization.r
@@ -1,0 +1,49 @@
+# normalization & standardization
+normalization<-function(x){
+  return((x-min(x))/(max(x)-min(x)))
+}
+
+standardization<-function(x){
+  return((x-mean(x))/sd(x))
+}
+
+head(iris)
+# Sepal.Length Sepal.Width Petal.Length Petal.Width Species
+# 1          5.1         3.5          1.4         0.2  setosa
+# 2          4.9         3.0          1.4         0.2  setosa
+# 3          4.7         3.2          1.3         0.2  setosa
+# 4          4.6         3.1          1.5         0.2  setosa
+# 5          5.0         3.6          1.4         0.2  setosa
+# 6          5.4         3.9          1.7         0.4  setosa
+
+iris<-iris[,-5]
+head(iris)
+# Sepal.Length Sepal.Width Petal.Length Petal.Width
+# 1          5.1         3.5          1.4         0.2
+# 2          4.9         3.0          1.4         0.2
+# 3          4.7         3.2          1.3         0.2
+# 4          4.6         3.1          1.5         0.2
+# 5          5.0         3.6          1.4         0.2
+# 6          5.4         3.9          1.7         0.4
+
+#normalize
+apply(as.matrix(iris),2,normalization)
+# Sepal.Length Sepal.Width Petal.Length Petal.Width
+# [1,]   0.22222222  0.62500000   0.06779661  0.04166667
+# [2,]   0.16666667  0.41666667   0.06779661  0.04166667
+# [3,]   0.11111111  0.50000000   0.05084746  0.04166667
+# [4,]   0.08333333  0.45833333   0.08474576  0.04166667
+# [5,]   0.19444444  0.66666667   0.06779661  0.04166667
+# [6,]   0.30555556  0.79166667   0.11864407  0.12500000
+# [7,]   0.08333333  0.58333333   0.06779661  0.08333333
+
+#standardize
+apply(as.matrix(iris),2,standardization)
+# Sepal.Length Sepal.Width Petal.Length   Petal.Width
+# [1,]  -0.89767388  1.01560199  -1.33575163 -1.3110521482
+# [2,]  -1.13920048 -0.13153881  -1.33575163 -1.3110521482
+# [3,]  -1.38072709  0.32731751  -1.39239929 -1.3110521482
+# [4,]  -1.50149039  0.09788935  -1.27910398 -1.3110521482
+# [5,]  -1.01843718  1.24503015  -1.33575163 -1.3110521482
+# [6,]  -0.53538397  1.93331463  -1.16580868 -1.0486667950
+# [7,]  -1.50149039  0.78617383  -1.33575163 -1.1798594716


### PR DESCRIPTION
61 This change cleans up redundant warnings that were emitted from multiple layers. The messages are now centralized and emitted once. This improves log clarity.